### PR TITLE
Added option to specify the archive format to write + Cleanup of tabs/spaces

### DIFF
--- a/lib/Archive/Cpio.pm
+++ b/lib/Archive/Cpio.pm
@@ -178,7 +178,7 @@ sub read_with_handler {
     my ($cpio, $F, $handler) = @_;
 
     my $FHwp = Archive::Cpio::FileHandle_with_pushback->new($F);
-    $cpio->{archive_format} ||= detect_archive_format($FHwp);
+    $cpio->{archive_format} = detect_archive_format($FHwp);
 
     while (my $entry = $cpio->{archive_format}->read_one($FHwp)) {
         $entry = Archive::Cpio::File->new($entry);

--- a/lib/Archive/Cpio.pm
+++ b/lib/Archive/Cpio.pm
@@ -155,8 +155,8 @@ sub add_data {
     my $entry = $opthashref || {};
     $entry->{name} = $filename;
     $entry->{data} = $data;
-    $entry->{nlink} = 1;
-    $entry->{mode} = 0100644;
+    $entry->{nlink} ||= 1;
+    $entry->{mode} ||= 0100644;
     push @{$cpio->{list}}, Archive::Cpio::File->new($entry);
 }
 

--- a/lib/Archive/Cpio.pm
+++ b/lib/Archive/Cpio.pm
@@ -10,7 +10,7 @@ use Archive::Cpio::OldBinary;
 
 Archive::Cpio - module for manipulations of cpio archives
 
-=head1 SYNOPSIS     
+=head1 SYNOPSIS
 
     use Archive::Cpio;
 
@@ -26,7 +26,7 @@ Archive::Cpio - module for manipulations of cpio archives
     my $cpio = Archive::Cpio->new;
     $cpio->read_with_handler(\*STDIN,
                 sub {
-                    my ($e) = @_;                   
+                    my ($e) = @_;
                     if ($e->name ne 'foo') {
                         $cpio->write_one(\*STDOUT, $e);
                     }
@@ -61,17 +61,17 @@ Reads the cpio file
 
 sub read {
     my ($cpio, $file) = @_;
-    
+
     my $IN;
     if (ref $file) {
-	$IN = $file;
+        $IN = $file;
     } else {
-	open($IN, '<', $file) or die "can't open $file: $!\n";
+        open($IN, '<', $file) or die "can't open $file: $!\n";
     }
 
-    read_with_handler($cpio, $IN, sub { 
+    read_with_handler($cpio, $IN, sub {
         my ($e) = @_;
-	push @{$cpio->{list}}, $e;
+        push @{$cpio->{list}}, $e;
     });
 }
 
@@ -88,9 +88,9 @@ sub write {
 
     my $OUT;
     if (ref $file) {
-	$OUT = $file;
+        $OUT = $file;
     } else {
-	open($OUT, '>', $file) or die "can't open $file: $!\n";
+        open($OUT, '>', $file) or die "can't open $file: $!\n";
     }
 
     $cpio->write_one($OUT, $_) foreach @{$cpio->{list}};
@@ -121,9 +121,9 @@ Returns a list of C<Archive::Cpio::File> (after a C<$cpio->read>)
 sub get_files {
     my ($cpio, @list) = @_;
     if (@list) {
-	map { get_file($cpio, $_) } @list;
+        map { get_file($cpio, $_) } @list;
     } else {
-	@{$cpio->{list}};
+        @{$cpio->{list}};
     }
 }
 
@@ -136,7 +136,7 @@ Returns the C<Archive::Cpio::File> matching C<$filename< (after a C<$cpio->read>
 sub get_file {
     my ($cpio, $file) = @_;
     foreach (@{$cpio->{list}}) {
-	$_->name eq $file and return $_;
+        $_->name eq $file and return $_;
     }
     undef;
 }
@@ -145,8 +145,8 @@ sub get_file {
 
 Takes a filename, a scalar full of data and optionally a reference to a hash with specific options.
 
-Will add a file to the in-memory archive, with name C<$filename> and content C<$data>. 
-Specific properties can be set using C<$opthashref>. 
+Will add a file to the in-memory archive, with name C<$filename> and content C<$data>.
+Specific properties can be set using C<$opthashref>.
 
 =cut
 
@@ -173,9 +173,9 @@ sub read_with_handler {
     $cpio->{archive_format} ||= detect_archive_format($FHwp);
 
     while (my $entry = $cpio->{archive_format}->read_one($FHwp)) {
-	$entry = Archive::Cpio::File->new($entry);
-	$handler->($entry);
-    }    
+        $entry = Archive::Cpio::File->new($entry);
+        $handler->($entry);
+    }
 }
 
 =head2 $cpio->write_one($filehandle, $entry)
@@ -210,16 +210,16 @@ sub detect_archive_format {
     my $s = $FHwp->read_ahead($max_length);
 
     foreach my $magic (keys %$magics) {
-	my $archive_format = $magics->{$magic};
-	begins_with($s, $magic) or next;
-	
-	#warn "found magic for $archive_format\n";
+        my $archive_format = $magics->{$magic};
+        begins_with($s, $magic) or next;
 
-	# perl_checker: require Archive::Cpio::NewAscii
-	# perl_checker: require Archive::Cpio::OldBinary
-	my $class = "Archive::Cpio::$archive_format";
-	eval "require $class";
-	return $class->new($magic, $s);
+        #warn "found magic for $archive_format\n";
+
+        # perl_checker: require Archive::Cpio::NewAscii
+        # perl_checker: require Archive::Cpio::OldBinary
+        my $class = "Archive::Cpio::$archive_format";
+        eval "require $class";
+        return $class->new($magic, $s);
     }
     die "invalid archive\n";
 }
@@ -228,4 +228,4 @@ sub detect_archive_format {
 
 Pascal Rigaux <pixel@mandriva.com>
 
-=cut 
+=cut

--- a/lib/Archive/Cpio/Common.pm
+++ b/lib/Archive/Cpio/Common.pm
@@ -8,10 +8,10 @@ our @EXPORT = qw(padding write_or_die max begins_with);
 
 sub magics() {
     {
-	"070707" => 'ODC',
-	"070701" => 'NewAscii',
-	"\xC7\x71" => 'OldBinary', # swabbed 070707
-	"\x71\xC7" => 'OldBinary', # 070707
+        "070707" => 'ODC',
+        "070701" => 'NewAscii',
+        "\xC7\x71" => 'OldBinary', # swabbed 070707
+        "\x71\xC7" => 'OldBinary', # 070707
     };
 }
 

--- a/lib/Archive/Cpio/FileHandle_with_pushback.pm
+++ b/lib/Archive/Cpio/FileHandle_with_pushback.pm
@@ -21,9 +21,9 @@ sub read {
     my $tmp = '';
 
     if ($FHwp->{already_read}) {
-	$tmp = substr($FHwp->{already_read}, 0, $size);
-	substr($FHwp->{already_read}, 0, $size) = '';
-	$size -= length($tmp);
+        $tmp = substr($FHwp->{already_read}, 0, $size);
+        substr($FHwp->{already_read}, 0, $size) = '';
+        $size -= length($tmp);
     }
     read($FHwp->{F}, $tmp, $size, length($tmp)) == $size or die "unexpected end of file while reading (got $tmp)\n";
     $tmp;

--- a/lib/Archive/Cpio/NewAscii.pm
+++ b/lib/Archive/Cpio/NewAscii.pm
@@ -51,11 +51,11 @@ sub read_one_header {
     my %h;
     my @header = @HEADER;
     while (@header) {
-	my $field = shift @header;
-	my $size =  shift @header;
-	$h{$field} = $FHwp->read($size);
-	$h{$field} =~ /^[0-9A-F]*$/si or die "bad header value $h{$field}\n";
-	$h{$field} = hex $h{$field};
+        my $field = shift @header;
+        my $size =  shift @header;
+        $h{$field} = $FHwp->read($size);
+        $h{$field} =~ /^[0-9A-F]*$/si or die "bad header value $h{$field}\n";
+        $h{$field} = hex $h{$field};
     }
     $h{magic} == $o->{magic} or die "bad magic ($h{magic} vs $o->{MAGIC})\n";
 
@@ -70,8 +70,8 @@ sub write_one {
     $entry->{datasize} = length($entry->{data});
 
     write_or_die($F, pack_header($entry) .
-		     $entry->{name} . "\0" .
-		     "\0" x padding(4, $entry->{namesize} + 2));
+                     $entry->{name} . "\0" .
+                     "\0" x padding(4, $entry->{namesize} + 2));
     write_or_die($F, $entry->{data});
     write_or_die($F, "\0" x padding(4, $entry->{datasize}));
 
@@ -89,7 +89,7 @@ sub cleanup_entry {
     my ($entry) = @_;
 
     foreach ('datasize', 'namesize', 'magic') {
-	delete $entry->{$_};
+        delete $entry->{$_};
     }
 }
 
@@ -99,10 +99,10 @@ sub pack_header {
     my $packed = '';
     my @header = @HEADER;
     while (@header) {
-	my $field = shift @header;
-	my $size =  shift @header;
+        my $field = shift @header;
+        my $size =  shift @header;
 
-	$packed .= sprintf("%0${size}X", $h->{$field} || 0);
+        $packed .= sprintf("%0${size}X", $h->{$field} || 0);
     }
     $packed;
 }

--- a/lib/Archive/Cpio/ODC.pm
+++ b/lib/Archive/Cpio/ODC.pm
@@ -46,11 +46,11 @@ sub read_one_header {
     my %h;
     my @header = @HEADER;
     while (@header) {
-	my $field = shift @header;
-	my $size =  shift @header;
-	$h{$field} = $FHwp->read($size);
-	$h{$field} =~ /^[0-9]*$/si or die "bad header value $h{$field}\n";
-	$h{$field} = oct $h{$field};
+        my $field = shift @header;
+        my $size =  shift @header;
+        $h{$field} = $FHwp->read($size);
+        $h{$field} =~ /^[0-9]*$/si or die "bad header value $h{$field}\n";
+        $h{$field} = oct $h{$field};
     }
     $h{magic} == $o->{magic} or die "bad magic ($h{magic} vs $o->{MAGIC})\n";
 
@@ -65,7 +65,7 @@ sub write_one {
     $entry->{datasize} = length($entry->{data});
 
     write_or_die($F, pack_header($entry) .
-		     $entry->{name} . "\0" . $entry->{data});
+                     $entry->{name} . "\0" . $entry->{data});
 
     cleanup_entry($entry);
 }
@@ -80,7 +80,7 @@ sub cleanup_entry {
     my ($entry) = @_;
 
     foreach ('datasize', 'namesize', 'magic') {
-	delete $entry->{$_};
+        delete $entry->{$_};
     }
 }
 
@@ -90,10 +90,10 @@ sub pack_header {
     my $packed = '';
     my @header = @HEADER;
     while (@header) {
-	my $field = shift @header;
-	my $size =  shift @header;
+        my $field = shift @header;
+        my $size =  shift @header;
 
-	$packed .= sprintf("%0${size}lo", $h->{$field} || 0);
+        $packed .= sprintf("%0${size}lo", $h->{$field} || 0);
     }
     $packed;
 }

--- a/lib/Archive/Cpio/OldBinary.pm
+++ b/lib/Archive/Cpio/OldBinary.pm
@@ -50,10 +50,10 @@ sub read_one_header {
     my %h;
     my @vals = unpack('v*', $FHwp->read(2 * @HEADER));
     foreach my $field (@HEADER) {
-	$h{$field} = shift @vals;
+        $h{$field} = shift @vals;
     }
     foreach ('mtime', 'datasize') {
-	$h{$_} = $h{$_ . '_high'} * 0x10000 + $h{$_ . '_low'};
+        $h{$_} = $h{$_ . '_high'} * 0x10000 + $h{$_ . '_low'};
     }
 
     $h{magic} == $o->{magic} or die "bad magic ($h{magic} vs $o->{MAGIC})\n";
@@ -69,13 +69,13 @@ sub write_one {
     $entry->{datasize} = length($entry->{data});
 
     foreach ('mtime', 'datasize') {
-	$entry->{$_ . '_high'} = int($entry->{$_} / 0x10000);
-	$entry->{$_ . '_low'} = $entry->{$_} % 0x10000;
+        $entry->{$_ . '_high'} = int($entry->{$_} / 0x10000);
+        $entry->{$_ . '_low'} = $entry->{$_} % 0x10000;
     }
 
     write_or_die($F, pack_header($entry) .
-		     $entry->{name} . "\0" .
-		     "\0" x padding(2, $entry->{namesize}));
+                     $entry->{name} . "\0" .
+                     "\0" x padding(2, $entry->{namesize}));
     write_or_die($F, $entry->{data});
     write_or_die($F, "\0" x padding(2, $entry->{datasize}));
 
@@ -93,10 +93,10 @@ sub cleanup_entry {
     my ($entry) = @_;
 
     foreach ('datasize', 'namesize', 'magic') {
-	delete $entry->{$_};
+        delete $entry->{$_};
     }
     foreach (keys %$entry) {
-	/_low$|_high$/ and delete $entry->{$_};
+        /_low$|_high$/ and delete $entry->{$_};
     }
 }
 


### PR DESCRIPTION
By adding the archive format, this fixes a blocking bug : ability to create an archive from scratch. Otherwise, the variable "archive_format" is not set (no call to detect_archive_format).

Thus, I renamed function "detect_archive_format" to "set_archive_format" and called it when the variable is not set.

Also, I forced the refresh of "archive_format" for each "read" call, so we can merge cpio from different formats
